### PR TITLE
Improved performance when dealing with large numbers of connections

### DIFF
--- a/org.osate.ge/src/org/osate/ge/internal/diagram/runtime/DiagramElement.java
+++ b/org.osate.ge/src/org/osate/ge/internal/diagram/runtime/DiagramElement.java
@@ -13,12 +13,14 @@ import org.osate.ge.graphics.Point;
 import org.osate.ge.graphics.Style;
 import org.osate.ge.graphics.internal.AgeGraphicalConfiguration;
 import org.osate.ge.internal.diagram.runtime.boTree.Completeness;
+import org.osate.ge.internal.query.RelativeReferenceProvider;
 import org.osate.ge.internal.query.Queryable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-public class DiagramElement implements DiagramNode, ModifiableDiagramElementContainer, BusinessObjectContext {
+public class DiagramElement
+		implements DiagramNode, ModifiableDiagramElementContainer, BusinessObjectContext, RelativeReferenceProvider {
 	private final DiagramNode container;
 
 	private Long id;

--- a/org.osate.ge/src/org/osate/ge/internal/query/DescendantsByBusinessObjectRelativeReferencesQuery.java
+++ b/org.osate.ge/src/org/osate/ge/internal/query/DescendantsByBusinessObjectRelativeReferencesQuery.java
@@ -11,26 +11,26 @@ public class DescendantsByBusinessObjectRelativeReferencesQuery extends DefaultQ
 	private final static RelativeBusinessObjectReference[] nullBoRefs = new RelativeBusinessObjectReference[0];
 	private final Supplier<Object, Object[]> bosSupplier;
 	private final int minSegments;
-	
+
 	private static class Match {
 		Queryable value;
 		int depth = -1;
-	}	
-	
-	public DescendantsByBusinessObjectRelativeReferencesQuery(final DefaultQuery prev, 
+	}
+
+	public DescendantsByBusinessObjectRelativeReferencesQuery(final DefaultQuery prev,
 			final Supplier<?, Object[]> bosSupplier) {
 		this(prev, bosSupplier, -1);
 	}
-	
+
 	@SuppressWarnings("unchecked")
-	public DescendantsByBusinessObjectRelativeReferencesQuery(final DefaultQuery prev, 
+	public DescendantsByBusinessObjectRelativeReferencesQuery(final DefaultQuery prev,
 			final Supplier<?, Object[]> bosSupplier,
-			final int minSegments) {
+					final int minSegments) {
 		super(prev);
 		this.bosSupplier = (Supplier<Object, Object[]>) Objects.requireNonNull(bosSupplier, "bosSupplier must not be null");
 		this.minSegments = minSegments;
 	}
-	
+
 	@Override
 	void run(final Deque<DefaultQuery> remainingQueries, final Queryable ctx, final QueryExecutionState state, final QueryResult result) {
 		// Look in the cache for the reference and build a new reference string if it is not found
@@ -43,57 +43,59 @@ public class DescendantsByBusinessObjectRelativeReferencesQuery extends DefaultQ
 			}
 			state.cache.put(this, boRefs);
 		}
-		
+
 		if(boRefs == nullBoRefs) {
 			return;
 		}
-		
+
 		final Match bestMatch = new Match();
-		findMatchingDescendants(remainingQueries, ctx, state, result, boRefs, bestMatch, 0);		
-		
+		findMatchingDescendants(remainingQueries, ctx, state, result, boRefs, bestMatch, 0);
+
 		// Return a partial match if a result has not been processed and a partial match was found
-		if(!result.done && 
-				allowPartialMatch() && 
-				bestMatch.depth >= minSegments && 
+		if(!result.done &&
+				allowPartialMatch() &&
+				bestMatch.depth >= minSegments &&
 				bestMatch.depth < boRefs.length) {
 			processResultValue(remainingQueries, bestMatch.value, state, result);
 		}
 	}
-	
+
 	private boolean allowPartialMatch() {
 		return minSegments > 0;
 	}
-	
-	void findMatchingDescendants(final Deque<DefaultQuery> remainingQueries, 
-			Queryable container, 
-			final QueryExecutionState state, 
-			final QueryResult result, 
+
+	void findMatchingDescendants(final Deque<DefaultQuery> remainingQueries,
+			Queryable container,
+			final QueryExecutionState state,
+			final QueryResult result,
 			final RelativeBusinessObjectReference[] boRefs,
-			final Match bestMatch, 
+			final Match bestMatch,
 			int currentDepth) {
 		if(currentDepth > bestMatch.depth) {
 			bestMatch.value = container;
 			bestMatch.depth = currentDepth;
 		}
-		
+
 		if(currentDepth >= boRefs.length) {
 			processResultValue(remainingQueries, container, state, result);
-		} else {		
+		} else {
 			final RelativeBusinessObjectReference boRef = boRefs[currentDepth];
 			for(final Queryable child : container.getChildren()) {
 				// Check the business object reference
-				final RelativeBusinessObjectReference childRef = state.refBuilder.getRelativeReference(child.getBusinessObject());
-				if(boRef.equals(childRef)) {
-					findMatchingDescendants(remainingQueries, child, state, result, boRefs, bestMatch, currentDepth+1);
-				}	
+				final RelativeBusinessObjectReference childRef = InternalQueryUtil.getRelativeReference(child,
+						state.refBuilder);
+				if (boRef.equals(childRef)) {
+					findMatchingDescendants(remainingQueries, child, state, result, boRefs, bestMatch,
+							currentDepth + 1);
+				}
 
-				if(result.done) {
+				if (result.done) {
 					return;
 				}
 			}
 		}
 	}
-	
+
 	/**
 	 * Returns an array of references for an array of business objects.
 	 * @param bos
@@ -104,22 +106,22 @@ public class DescendantsByBusinessObjectRelativeReferencesQuery extends DefaultQ
 		if(bos == null) {
 			return null;
 		}
-		
+
 		final RelativeBusinessObjectReference[] references = new RelativeBusinessObjectReference[bos.length];
 		for(int i = 0; i < bos.length; i++) {
 			final Object bo = bos[i];
 			if(bo == null) {
 				return null;
 			}
-			
+
 			final RelativeBusinessObjectReference ref = refBuilder.getRelativeReference(bo);
 			if(ref == null) {
 				return null;
 			}
-			
-			references[i] = ref;			
+
+			references[i] = ref;
 		}
-		
+
 		return references;
 	}
 }

--- a/org.osate.ge/src/org/osate/ge/internal/query/DescendantsByBusinessObjectRelativeReferencesQuery.java
+++ b/org.osate.ge/src/org/osate/ge/internal/query/DescendantsByBusinessObjectRelativeReferencesQuery.java
@@ -65,12 +65,12 @@ public class DescendantsByBusinessObjectRelativeReferencesQuery extends DefaultQ
 	}
 
 	void findMatchingDescendants(final Deque<DefaultQuery> remainingQueries,
-			Queryable container,
+			final Queryable container,
 			final QueryExecutionState state,
 			final QueryResult result,
 			final RelativeBusinessObjectReference[] boRefs,
 			final Match bestMatch,
-			int currentDepth) {
+			final int currentDepth) {
 		if(currentDepth > bestMatch.depth) {
 			bestMatch.value = container;
 			bestMatch.depth = currentDepth;

--- a/org.osate.ge/src/org/osate/ge/internal/query/FilterByBusinessObjectRelativeReferenceQuery.java
+++ b/org.osate.ge/src/org/osate/ge/internal/query/FilterByBusinessObjectRelativeReferenceQuery.java
@@ -9,13 +9,13 @@ import org.osate.ge.query.Supplier;
 class FilterByBusinessObjectRelativeReferenceQuery extends DefaultQuery {
 	private final Supplier<Object, Object> boSupplier;
 	private RelativeBusinessObjectReference nullBoRef = new RelativeBusinessObjectReference("<null>");
-	
+
 	@SuppressWarnings("unchecked")
 	public FilterByBusinessObjectRelativeReferenceQuery(final DefaultQuery prev, final Supplier<?, Object> boSupplier) {
 		super(prev);
 		this.boSupplier = (Supplier<Object, Object>) Objects.requireNonNull(boSupplier, "boSupplier must not be null");
 	}
-	
+
 	@Override
 	void run(final Deque<DefaultQuery> remainingQueries, final Queryable ctx, final QueryExecutionState state, final QueryResult result) {
 		// Look in the cache for the reference and build a new reference string if it is not found
@@ -28,14 +28,15 @@ class FilterByBusinessObjectRelativeReferenceQuery extends DefaultQuery {
 			}
 			state.cache.put(this, boRef);
 		}
-		
+
 		if(boRef == nullBoRef) {
 			return;
 		}
-		
+
 		// Compare references
 		if(ctx.getBusinessObject() != null) {
-			final RelativeBusinessObjectReference ctxRelativeReference = state.refBuilder.getRelativeReference(ctx.getBusinessObject());
+			final RelativeBusinessObjectReference ctxRelativeReference = InternalQueryUtil.getRelativeReference(ctx,
+					state.refBuilder);
 			if(ctxRelativeReference != null && ctxRelativeReference.equals(boRef)) {
 				processResultValue(remainingQueries, ctx, state, result);
 			}

--- a/org.osate.ge/src/org/osate/ge/internal/query/InternalQueryUtil.java
+++ b/org.osate.ge/src/org/osate/ge/internal/query/InternalQueryUtil.java
@@ -1,0 +1,15 @@
+package org.osate.ge.internal.query;
+
+import org.osate.ge.internal.diagram.runtime.RelativeBusinessObjectReference;
+import org.osate.ge.services.ReferenceBuilderService;
+
+interface InternalQueryUtil {
+	public static RelativeBusinessObjectReference getRelativeReference(final Queryable q,
+			final ReferenceBuilderService refBuilder) {
+		if (q instanceof RelativeReferenceProvider) {
+			return ((RelativeReferenceProvider) q).getRelativeReference();
+		}
+
+		return refBuilder.getRelativeReference(q.getBusinessObject());
+	}
+}

--- a/org.osate.ge/src/org/osate/ge/internal/query/RelativeReferenceProvider.java
+++ b/org.osate.ge/src/org/osate/ge/internal/query/RelativeReferenceProvider.java
@@ -1,0 +1,12 @@
+package org.osate.ge.internal.query;
+
+import org.osate.ge.internal.diagram.runtime.RelativeBusinessObjectReference;
+
+/**
+ * Indicates that the object can provide the relative reference associated with it's business object.
+ * Optional interface that can be implemented by queryables for optimization purposes.
+ *
+ */
+public interface RelativeReferenceProvider {
+	RelativeBusinessObjectReference getRelativeReference();
+}


### PR DESCRIPTION
Improved performance when dealing with large numbers of connections by
allowing DiagramElement to provide relative reference to query service
instead of building references repeatedly.

Implements optimizations as described in the comments of #290.  Test and then we can merge during the new release cycle to allow for more testing before this makes its way to the stable build.